### PR TITLE
docs: add link to package site

### DIFF
--- a/raco-run/scribblings/raco-run.scrbl
+++ b/raco-run/scribblings/raco-run.scrbl
@@ -9,6 +9,8 @@
 @title{raco-run}
 @author[(author+email "Sam Phillips" "samdphillips@gmail.com")]
 
+@defmodule[raco-run]
+
 @url{https://github.com/samdphillips/raco-run}
 
 Provides a @exec{raco run} sub-command for executing submodules.


### PR DESCRIPTION
A use of defmodule links to the Racket package index on the built Racket documentation (cf. raco fmt), which also gives a clearer indication of how to `raco pkg install` the command.

(With my apologies for the unwrapped commit message—blame GitHub UI and my own laziness to not clone the fork this time.)